### PR TITLE
Metric logging

### DIFF
--- a/applications/train.py
+++ b/applications/train.py
@@ -3,7 +3,6 @@ from torch.utils.data import DataLoader
 from torch import nn as nn
 import torch.backends.cudnn as cudnn
 from torch.optim import lr_scheduler
-import pandas as pd
 from thermostability.thermo_pregenerated_dataset import (
     ThermostabilityPregeneratedDataset,
     zero_padding700_collate,

--- a/applications/train.py
+++ b/applications/train.py
@@ -3,7 +3,7 @@ from torch.utils.data import DataLoader
 from torch import nn as nn
 import torch.backends.cudnn as cudnn
 from torch.optim import lr_scheduler
-
+import pandas as pd
 from thermostability.thermo_pregenerated_dataset import (
     ThermostabilityPregeneratedDataset,
     zero_padding700_collate,
@@ -33,7 +33,7 @@ if torch.cuda.is_available():
 cpu = torch.device("cpu")
 torch.cuda.empty_cache()
 torch.cuda.list_gpu_processes()
-from util.train_helper import train_model
+from util.train_helper import train_model, calculate_metrics
 from datetime import datetime as dt
 from util.experiments import store_experiment
 from thermostability.uni_prot_dataset import UniProtDataset
@@ -199,6 +199,8 @@ def run_train_experiment(
         ]
         table = wandb.Table(data=data, columns=["predictions", "labels"])
         wandb.log({"predictions": wandb.plot.scatter(table, "predictions", "labels")})
+        metrics = calculate_metrics(best_epoch_predictions, best_epoch_actuals)
+        wandb.log(metrics)
     elif should_log:
         store_experiment(
             results_path,

--- a/util/experiments.py
+++ b/util/experiments.py
@@ -1,5 +1,6 @@
 import json
 from util.plotting import plot_predictions
+from util.train_helper import calculate_metrics
 import os
 from typing_extensions import Literal
 import matplotlib.pyplot as plt
@@ -33,5 +34,9 @@ def store_experiment(
         plt.title(f"MAD over epochs")
         plt.legend(epoch_mads.keys())    
         plt.savefig(os.path.join(output_dir_path, f"mads.png"))
+
+    metrics = calculate_metrics(epoch_predictions, epoch_actuals)
+    with open(os.path.join(output_dir_path, "metrics.json"), "w") as f:
+        json.dump(metrics, indent=5)
 
     print(f"Results stored in {output_dir_path}")

--- a/util/train_helper.py
+++ b/util/train_helper.py
@@ -11,10 +11,10 @@ import pandas as pd
 def calculate_metrics(predictions, labels):
     diffs = pd.Series([abs(pred - labels[i]) for (i, pred) in enumerate(predictions)])
     return {
-            "spearman_r_s": spearmanr(predictions, labels),
-            "max_diff": diffs.max(),
-            "median_diff": diffs.median(),
-            "mean_diff": diffs.mean()
+            "best_epoch_spearman_r_s_val": spearmanr(predictions, labels).correlation,
+            "best_epoch_max_abs_diff_val": diffs.max(),
+            "best_epoch_median_abs_diff_val": diffs.median(),
+            "best_epoch_mean_abs_diff_val": diffs.mean()
             }
 
 def execute_epoch(
@@ -162,11 +162,8 @@ def train_model(
     print(f"Training complete in {time_elapsed // 60:.0f}m {time_elapsed % 60:.0f}s")
     print(f"Best val Acc: {best_epoch_loss:4f}")
 
-    if use_wandb:
-        wandb.log({'best_mad_val': best_val_mad})
-
     # load best model weights
     if best_model_path:
         model = torch.load(best_model_path)
     
-    return model, best_epoch_loss, best_val_mad ,epoch_mads,best_epoch_actuals, best_epoch_predictions
+    return model, best_epoch_loss, best_val_mad, epoch_mads, best_epoch_actuals, best_epoch_predictions

--- a/util/train_helper.py
+++ b/util/train_helper.py
@@ -5,8 +5,17 @@ from tqdm.notebook import tqdm
 import sys
 import wandb
 from typing import Callable
+from scipy.stats import spearmanr
+import pandas as pd
 
-
+def calculate_metrics(predictions, labels):
+    diffs = pd.Series([abs(pred - labels[i]) for (i, pred) in enumerate(predictions)])
+    return {
+            "spearman_r_s": spearmanr(predictions, labels),
+            "max_diff": diffs.max(),
+            "median_diff": diffs.median(),
+            "mean_diff": diffs.mean()
+            }
 
 def execute_epoch(
     model: nn.Module,


### PR DESCRIPTION
Closes #16 

Metrics like mean absolute diff, max absolute diff, median absolute diff, spearman rank correlation are logged locally and on the wandb server.